### PR TITLE
Add script for hot reloading watcher

### DIFF
--- a/run-live-reload.sh
+++ b/run-live-reload.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Hot reload helper for Spring Boot
+#
+# Run this script in a separate terminal. It watches your source files and
+# automatically recompiles them when you save.
+#
+# In another terminal, start your app with:
+#   ./gradlew bootRun
+#
+# The app will restart automatically on changes, 
+# so you can just refresh your browser without manually stopping and restarting the process.
+#
+# After you changed a file, it might take a few seconds for hot reload to reload your application.
+# ------------------------------------------------------------------------------
+
+set -e
+
+echo "👀 Starting Gradle continuous class compilation..."
+
+# Ensure wrapper exists
+if [ ! -f "./gradlew" ]; then
+  echo "⚙️ Generating Gradle wrapper..."
+  gradle wrapper
+fi
+
+chmod +x ./gradlew
+
+# Clean shutdown
+cleanup() {
+  echo ""
+  echo "🛑 Stopping watcher..."
+  kill 0
+}
+trap cleanup EXIT
+
+# Start continuous compilation
+./gradlew classes --continuous -x test


### PR DESCRIPTION
This script starts a watcher that recompiles the code so that participants dont need to exit the process and reopen the tab for every change. With this script running in a second terminal tab, one can just make changes and it gets synced. Only need to refresh the webpage after that.

We considered adding it to `.devcontainer` to run it automatically, but that might also confuse people who try running it themselves. Therefore, we can start with a script and can iterate on the approach.